### PR TITLE
add setOAuthCredentials function to supply the client with existing oAuth token and secret

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,13 @@ module.exports = class Instapaper {
     this.password = password;
   }
 
+  setOAuthCredentials(token, secret) {
+    this.token = {
+      key: token,
+      secret: secret
+    }
+  }
+
   authorize = () => {
     return new Promise((resolve, reject) => {
       if (this.token) {

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,12 @@ $ npm i instapaper-node-sdk
 
 const Instapaper = require('instapaper-node-sdk')
 const client = new Instapaper(KEY, SECRET)
+
+// Use supplied Username/Password to get an oAuth key and secret
 client.setCredentials(USERNAME, PASSWORD)
+
+// Alternatively if you already have an oAuth key and secret, supply them directly to the client
+client.setOAuthCredentials(TOKEN, SECRET)
 
 // get the list of your bookmarks
 client.list({ limit: 100 }).then((data) => console.log(data)).catch((err) => console.log(err))


### PR DESCRIPTION
Rather than needing to supply the client a username/password each time, allow the client to be build with an existing oAuth token and secret. This allows for token caching vs needing the user to supply a username and password to the application each time.

Sample:

```js
const client = new Instapaper(CONSUMER_KEY, CONSUMER_SECRET);
client.setOAuthCredentials(TOKEN, SECRET);
```
